### PR TITLE
Build pyshp on Python 3, too.

### DIFF
--- a/pyshp/upload_all.sh
+++ b/pyshp/upload_all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+conda config --set binstar_upload yes
+
+for PY in 27 33 34
+do
+    export CONDA_PY=$PY
+    conda build .
+done


### PR DESCRIPTION
To be honest, I'm not really sure how this works. I just copied what's in `pyepsg`. `pyshp` on Python 3 is needed for Cartopy (soon, I hope!)