### PR TITLE
Changed from ssh to https.

### DIFF
--- a/biggus/meta.yaml
+++ b/biggus/meta.yaml
@@ -3,7 +3,7 @@ package:
     version: "0.7.0"
 
 source:
-    git_url: git@github.com:SciTools/biggus.git
+    git_url: https://github.com/SciTools/biggus.git
     git_tag: v0.7.0
 
 requirements:

--- a/pyepsg/meta.yaml
+++ b/pyepsg/meta.yaml
@@ -3,7 +3,7 @@ package:
     version: "0.2.0"
 
 source:
-    git_url: git@github.com:rhattersley/pyepsg.git
+    git_url: https://github.com/rhattersley/pyepsg.git
     git_tag: v0.2.0
 
 requirements:


### PR DESCRIPTION
I am using conda-recipes-scitools repository as a git submodule in another project.  For that it would be nice to have all the URLs as `http` instead of `ssh` to easy the package build.  (No github not password require to build the package.)

PS: This should close issue #8.
