### PR TITLE
Changes needed for Linux32 building. Closes #27.

### DIFF
--- a/cdat-lite/meta.yaml
+++ b/cdat-lite/meta.yaml
@@ -8,18 +8,18 @@ source:
     sha1: 8d7f373367cd05c0378d310ce78ee4a1a68d258b
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
         - python
-        - numpy
+        - numpy <1.9 # Depends on oldnumeric, which was removed in v1.9.
         - setuptools
         - libnetcdf 4.*
         - hdf5
     run:
         - python
-        - numpy
+        - numpy <1.9
         - libnetcdf 4.*
         - hdf5
 

--- a/ecmwf_grib/build.sh
+++ b/ecmwf_grib/build.sh
@@ -5,6 +5,7 @@ $SYS_PYTHON -c "import conda_build; print conda_build.__file__;"
 mkdir -p $PREFIX/bin
 cp $SYS_PYTHON-config $PREFIX/bin/
 
+export C_INCLUDE_PATH=$INCLUDE_PATH
 LDFLAGS="-L$PREFIX/lib" PYTHON="$PYTHON" PYTHON_LDFLAGS=$PREFIX/lib CFLAGS="-fPIC -Wl,-rpath,$PREFIX/lib" ./configure --with-jasper=$PREFIX/lib --disable-fortran --prefix=$PREFIX --enable-python
 
 make

--- a/jasper/build.sh
+++ b/jasper/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 export LDFLAGS=-L$LD_RUN_PATH
+export C_INCLUDE_PATH=$INCLUDE_PATH
+
 sh configure --prefix=$PREFIX --enable-shared
 make
 make install

--- a/jasper/meta.yaml
+++ b/jasper/meta.yaml
@@ -8,7 +8,7 @@ source:
     sha1: 9c5735f773922e580bf98c7c7dfda9bbed4c5191
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:

--- a/udunits/build.sh
+++ b/udunits/build.sh
@@ -2,7 +2,7 @@
 
 if [ ! -f configure ];
 then
-   # Make the configure file
+   # Make the configure file. Need autoreconf, libtool, libexpat-dev for this.
    autoreconf -i --force
 fi
 


### PR DESCRIPTION
These changes were discovered when building on a clean 32-bit Ubuntu installation. We don't have CI which _requires_ these, but the CI should tell us that the OSes that we have targeted to date do still work.
