### PR TITLE
Change git_url to use https protocol

### DIFF
--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -3,7 +3,7 @@ package:
     version: 1.7.2
 
 source:
-    git_url: git@github.com:SciTools/iris.git
+    git_url: https://github.com/SciTools/iris.git
     git_tag: v1.7.2
 
 build:


### PR DESCRIPTION
Change the `git_url` setting in the Iris build recipe to use the https protocol instead of the git protocol. This will aid Travis build support.
