### PR TITLE
Add x64 to build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ environment:
     - TARGET_ARCH: "x86"
       CONDA_PY: "27"
       CONDA_NPY: "18"
+    - TARGET_ARCH: "x64"
+      CONDA_PY: "27"
+      CONDA_NPY: "18"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.


### PR DESCRIPTION
Add a build command for building on Windows x64 to the AppVeyor build matrix.
