### PR TITLE
Use a released version of Obvious-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     # Install makeinfo - needed for constructing configuration files via autoreconf (in particular for udunits)
     - if [[ "$OSTYPE" == "linux-gnu" ]]; then sudo apt-get install texinfo; fi
 
-    - wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+    - wget https://raw.githubusercontent.com/pelson/Obvious-CI/v0.1.0/bootstrap-obvious-ci-and-miniconda.py
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
     - conda config --set show_channel_urls True && conda config --add channels http://conda.binstar.org/pelson/channel/main
     - conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ platform:
 
 install:
     - cmd: cinst wget -x86
-    - cmd: wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py --no-check-certificate
+    - cmd: wget https://raw.githubusercontent.com/pelson/Obvious-CI/v0.1.0/bootstrap-obvious-ci-and-miniconda.py --no-check-certificate
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1


### PR DESCRIPTION
Access the Obvious-CI bootstrap script from specific version

See issue https://github.com/SciTools/conda-recipes-scitools/issues/41
