### PR TITLE
BLD: Updated biggus tag release

### DIFF
--- a/biggus/meta.yaml
+++ b/biggus/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: biggus
-    version: "0.7.0"
+    version: "0.8.0"
 
 source:
     git_url: https://github.com/SciTools/biggus.git
-    git_tag: v0.7.0
+    git_tag: v0.8.0
 
 requirements:
     build:


### PR DESCRIPTION
Not sure if its worth me doing this PR (since I'm guessing I don't have permissions to push the package to the scitools binstar channel..) but thought I would since there is a disconnect with packages which require the newest tag release.

Worth putting up even if it acts as a reminder for an update.