### PR TITLE
increment version to 0.11.3.dev

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cartopy
-  version: 0.11.2.dev
+  version: 0.11.3.dev
 
 source:
   git_url: https://github.com/SciTools/cartopy.git
@@ -10,8 +10,7 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 0     # [not win]
-  number: 1     # [win]
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Cartopy 0.11.2 has been released so the current dev release version should now be 0.11.3.dev (according to https://www.python.org/dev/peps/pep-0440/ - the examples help). This should also trigger a new build which I'd like to make available since https://github.com/SciTools/cartopy/pull/532 was merged fixing the Natural Earth URL.