### PR TITLE
iris 1.7.4-dev

### DIFF
--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -1,12 +1,10 @@
 package:
     name: iris
-    version: 1.7.2.dev
+    version: 1.7.4.dev
 
 source:
-    git_url: https://github.com/SciTools/iris.git # [not win]
-    git_tag: v1.7.x  # [not win]
-    git_url: https://github.com/pelson/iris.git # [win]
-    git_tag: windows_build  # [win]
+    git_url: https://github.com/SciTools/iris.git
+    git_tag: v1.7.x
 
 build:
     number: 0


### PR DESCRIPTION
updating Iris recipe to use 1.7.x, which is currently 1.7.4-dev

this includes the fix for windows building which didn't make it inot the 1.7.3 release