### PR TITLE
32 and 64 geos buid flags

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,7 +10,7 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/geos/build.sh
+++ b/geos/build.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
 
-# Problems with cartopy if the -64 flag is not defined. See https://taskman.eionet.europa.eu/issues/14817.
-CFLAGS="-m64" CPPFLAGS="-m64" CXXFLAGS="-m64" LDFLAGS="-m64" FFLAGS="-m64" ./configure --prefix=$PREFIX --without-jni
+# Problems with cartopy if the -m{32,64} flag is not defined.
+# See https://taskman.eionet.europa.eu/issues/14817.
+
+MACHINE_TYPE=`uname -m`
+if [ ${MACHINE_TYPE} == 'x86_64' ]; then
+  ARCH="-m64"
+else
+  ARCH="-m32"
+fi
+
+CFLAGS=${ARCH} CPPFLAGS=${ARCH} CXXFLAGS=${ARCH} LDFLAGS=${ARCH} FFLAGS=${ARCH} \
+    ./configure --prefix=$PREFIX --without-jni
+
 make
 make install

--- a/shapely/meta.yaml
+++ b/shapely/meta.yaml
@@ -10,7 +10,7 @@ source:
     - osx-geos.patch        # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This PR makes adds a 32 build flag in case someone tries to build these recipes in a 32-Linux.  (See https://github.com/ioos/conda-recipes/pull/232)