### PR TITLE
Fix building cartopy packages on Python 3.

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - six
     - mock
     - nose
-    - pil
+    - pillow
     - owslib
     - numpy
     - proj4


### PR DESCRIPTION
This changes dependency to only use PIL on 2.x and use pillow on 3.x.