### PR TITLE
Limited ECMWF GRIB building to py2 on OSX. 

### DIFF
--- a/ecmwf_grib/meta.yaml
+++ b/ecmwf_grib/meta.yaml
@@ -15,7 +15,8 @@ build:
 
 requirements:
     build:
-        - python
+        - python  # [not osx]
+        - python <3  # [osx]
         # We must bake the numpy version into the build string.
         - numpy *
         - jasper


### PR DESCRIPTION
See #88.