### PR TITLE
Re-built cartopy for Linux.

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,7 +10,8 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 0
+  number: 0  # [not linux]
+  number: 1  # [linux]
 
 requirements:
   build:


### PR DESCRIPTION
Continues the saga from #101 and builds cartopy on an older linux OS.

