### PR TITLE
Fix AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,8 @@ platform:
     - x64
 
 install:
-    - cmd: python -c "from urllib2 import urlopen; open('bootstrap-obvious-ci-and-miniconda.py', 'w').write(urlopen('https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py').read())"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
+    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% 3 --without-obvci
     - cmd: set CONDA_PY=%CONDA_PY%
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1

--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - owslib
     - pyshp
     - pyepsg
-  
+
   run:
     - python
     - six


### PR DESCRIPTION
The first change is just for fun.  (I spent the weekend reading AppVeyor's docs.)

The second change should fix the problem we are seeing in #113. One side effect is that the Python 2.7 builds will be slightly slower.