### PR TITLE
Prepared for ObviousCI which no longer looks at whether a build.sh/bld.bat exists.

### DIFF
--- a/cdat-lite/meta.yaml
+++ b/cdat-lite/meta.yaml
@@ -10,6 +10,7 @@ source:
         - patch.diff  # [osx]
 
 build:
+    skip: True  # [win]
     number: 2
 
 requirements:

--- a/cfchecker/meta.yaml
+++ b/cfchecker/meta.yaml
@@ -10,8 +10,8 @@ source:
         - patch.diff  # [osx]
 
 build:
+    skip: True  # [win]
     number: 1
-
     entry_points:
         - cfchecks = cfchecker:cfchecks_main
 

--- a/ecmwf_grib/meta.yaml
+++ b/ecmwf_grib/meta.yaml
@@ -8,6 +8,7 @@ source:
     sha1: b769ac5db70703f0d944d93aafbbeee7513958f1
 
 build:
+    skip: True  # [win]
     number: 5
     detect_binary_files_with_prefix: true
 

--- a/expat/meta.yaml
+++ b/expat/meta.yaml
@@ -6,4 +6,5 @@ source:
     url: http://sourceforge.net/projects/expat/files/expat/2.1.0/expat-2.1.0.tar.gz/download
 
 build:
+    skip: True # [not win]
     number: 6

--- a/jasper/meta.yaml
+++ b/jasper/meta.yaml
@@ -8,6 +8,7 @@ source:
     sha1: 9c5735f773922e580bf98c7c7dfda9bbed4c5191
 
 build:
+    skip: True  # [win]
     number: 2  # [not linux]
     number: 3  # [linux]
 

--- a/libmo_unpack/meta.yaml
+++ b/libmo_unpack/meta.yaml
@@ -7,6 +7,7 @@ source:
     git_rev: v3.0
 
 build:
+    skip: True  # [win]
     number: 0  # [not linux]
     number: 2  # [linux]
 

--- a/mo_pack/meta.yaml
+++ b/mo_pack/meta.yaml
@@ -7,6 +7,7 @@ source:
   git_tag: v0.2.0
 
 build:
+  skip: True  # [win]
   number: 1
 
 requirements:


### PR DESCRIPTION
Ping @ocefpaf - this is coming in a PR for ObviousCI shortly.

FWIW:

```
>>> from glob import glob
>>> import os

>>> recipes = glob('*/meta.yaml')
>>> for recipe in recipes:
...     build = os.path.join(os.path.dirname(recipe), 'bld.bat')
...     print recipe, os.path.exists(build)
... 
biggus/meta.yaml True
cartopy/meta.yaml True
cdat-lite/meta.yaml False
cf_units/meta.yaml True
cfchecker/meta.yaml False
ecmwf_grib/meta.yaml False
expat/meta.yaml True
geos/meta.yaml True
iris/meta.yaml True
jasper/meta.yaml False
libmo_unpack/meta.yaml False
mo_pack/meta.yaml False
obvious-ci/meta.yaml True
owslib/meta.yaml True
proj4/meta.yaml True
pyepsg/meta.yaml True
pyke/meta.yaml True
pyshp/meta.yaml True
python-dateutil/meta.yaml True
pyugrid/meta.yaml True
shapely/meta.yaml True
shapely_old/meta.yaml True
udunits/meta.yaml True
>>> for recipe in recipes:
...     build = os.path.join(os.path.dirname(recipe), 'build.sh')
...     print recipe, os.path.exists(build)
... 
biggus/meta.yaml True
cartopy/meta.yaml True
cdat-lite/meta.yaml True
cf_units/meta.yaml True
cfchecker/meta.yaml True
ecmwf_grib/meta.yaml True
expat/meta.yaml False
geos/meta.yaml True
iris/meta.yaml True
jasper/meta.yaml True
libmo_unpack/meta.yaml True
mo_pack/meta.yaml True
obvious-ci/meta.yaml True
owslib/meta.yaml True
proj4/meta.yaml True
pyepsg/meta.yaml True
pyke/meta.yaml True
pyshp/meta.yaml True
python-dateutil/meta.yaml True
pyugrid/meta.yaml True
shapely/meta.yaml True
shapely_old/meta.yaml True
udunits/meta.yaml True
```