### PR TITLE
Added numpy as a build dependency of iris.

### DIFF
--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -16,6 +16,7 @@ requirements:
         - biggus >=0.10
         - cartopy >=0.12
         - netcdf4
+        - numpy x.x
         - udunits 2.*
         - pyke
         - setuptools


### PR DESCRIPTION
This will make iris build against all possible numpy combinations...
However, there may be some issues to deal with if some dependencies don't support those combinations...