### PR TITLE
Removed the test outputs for cartopy and iris.

### DIFF
--- a/cartopy/bld.bat
+++ b/cartopy/bld.bat
@@ -2,4 +2,6 @@ set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
+rmdir lib\cartopy\tests\mpl\baseline_images /s /q
+
 %PYTHON% setup.py install

--- a/cartopy/build.sh
+++ b/cartopy/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+rm -rf lib/cartopy/tests/mpl/baseline_images
+
 ${PYTHON} -sE setup.py install --single-version-externally-managed  --record record.txt

--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,8 +10,8 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 0  # [not linux]
-  number: 1  # [linux]
+  number: 2
+  number: 2
 
 requirements:
   build:

--- a/iris/bld.bat
+++ b/iris/bld.bat
@@ -2,4 +2,7 @@ set SITECFG=lib/iris/etc/site.cfg
 echo [System] > %SITECFG%
 echo udunits2_path = %SCRIPTS%\udunits2.dll >> %SITECFG%
 
+rmdir lib\iris\tests\results /s /q
+rmdir lib\iris\tests\*.npz /s /q
+
 %PYTHON% -sE setup.py install --single-version-externally-managed --record record.txt

--- a/iris/build.sh
+++ b/iris/build.sh
@@ -13,4 +13,6 @@ SITECFG=lib/iris/etc/site.cfg
 echo "[System]" > $SITECFG
 echo "udunits2_path = $PREFIX/lib/libudunits2.${EXT}" >> $SITECFG 
 
+rm -rf lib/iris/tests/results lib/iris/tests/*.npz
+
 $PYTHON -sE setup.py --with-unpack build_ext "-I${PREFIX}/include" "-L${PREFIX}/lib" "-R${PREFIX}/lib" install --single-version-externally-managed --record record.txt


### PR DESCRIPTION
iris: from ~27MB to ~2MB
cartopy: ~8MB to ~ 1.5MB 