### PR TITLE
Skip proj.4 build for Win32+Python 3.5 and cartopy for Win+Python 3.5

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 2
+  skip: True  # [py35 and win]
 
 requirements:
   build:

--- a/proj.4/meta.yaml
+++ b/proj.4/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
     number: 1
+    skip: True  # [py35 and win32]
 
 requirements:
     run:


### PR DESCRIPTION
I am trying to build the packages in the ioos against Python 3.5 and I noticed a weird bug when building proj.4 on Windows. (See https://github.com/ioos/conda-recipes/issues/588.)

Can we skip this build for now so I can get the rest of the packages going?

Update: Cartopy won't build on win32 without proj.4 and it is failing on win64 (see https://github.com/SciTools/cartopy/issues/699), so I am skipping cartopy for Python 3.5 too.