### PR TITLE
nc_time_axis recipe

### DIFF
--- a/nc_time_axis/bld.bat
+++ b/nc_time_axis/bld.bat
@@ -1,0 +1,1 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt

--- a/nc_time_axis/build.sh
+++ b/nc_time_axis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/nc_time_axis/meta.yaml
+++ b/nc_time_axis/meta.yaml
@@ -1,0 +1,29 @@
+package:
+    name: nc_time_axis
+    version: "1.0.0"
+
+source:
+    git_url: https://github.com/SciTools/nc-time-axis.git
+    git_tag: v1.0.0
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - six
+        - matplotlib
+        - netcdf4 >=1.1
+        - numpy
+
+test:
+    imports:
+        - nc_time_axis
+
+about:
+    license: BSD3
+    summary: 'Support for netcdftime axis in matplotlib.'


### PR DESCRIPTION
Once nc-time-axis has been tagged this can be added.

To use nc-time-axis in iris, we need to add this recipe to the scitools channel