### PR TITLE
Add iris as a testing requirement; test via setup.

### DIFF
--- a/iris-grib/meta.yaml
+++ b/iris-grib/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
     skip: True  # [win or py3k]
-    number: 2
+    number: 3
     script:
         - python setup.py install --single-version-externally-managed --record record.txt
 
@@ -21,9 +21,13 @@ requirements:
         - python
         - ecmwf_grib
 
-# test:
-#     imports:
-#         - iris_grib
+test:
+    requires:
+        - iris
+        - iris_sample_data
+        - pep8
+    commands:
+        - python -m unittest discover -v iris_grib.tests
 
 about:
     home: http://scitools.org.uk/iris-grib


### PR DESCRIPTION
If this works, it should reinstate testing in the iris_grib build process.

If good, closes #185 ?