### PR TITLE
Unpin conda-build version for circle

### DIFF
--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -49,7 +49,7 @@ conda install -n root --yes --quiet jinja2 anaconda-client
 conda clean --lock
 
 conda install --yes anaconda-client
-conda install --yes conda-build=1.18.2
+conda install --yes conda-build
 conda info
 unset LANG
 yum install -y expat-devel git autoconf libtool texinfo check-devel gcc-gfortran


### PR DESCRIPTION
The pinned version of conda-build was quite out of date, so let's remove the pin.