### PR TITLE
iris_grib dependency naming

### DIFF
--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: v1.10.0
 
 build:
-    number: 1
+    number: 2
     # See https://github.com/SciTools/cartopy/pull/676
     skip: True  # [py35]
 
@@ -26,7 +26,7 @@ requirements:
         - setuptools
         - mo_pack  # [not win]
         - nc_time_axis
-        - iris-grib  # [not win]
+        - iris_grib  # [not win]
     run:
         - python  # [not osx]
         - python >=2.7,<3  # [osx]
@@ -43,7 +43,7 @@ requirements:
         - cf_units
         - mo_pack  # [not win]
         - nc_time_axis
-        - iris-grib  # [not win]
+        - iris_grib  # [not win]
 
 test:
     imports:

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -17,7 +17,7 @@ requirements:
         - python >=2.7,<3  # [osx]
         - scipy
         - biggus >=0.14
-        - cartopy >=0.14
+        - cartopy >=0.13
         - netcdf4
         - numpy x.x
         - udunits2
@@ -32,7 +32,7 @@ requirements:
         - python >=2.7,<3  # [osx]
         - scipy
         - biggus >=0.14
-        - cartopy >=0.14
+        - cartopy >=0.13
         - matplotlib
         - netcdf4
         - ecmwf_grib >=1.12.1  # [not win and not py3k]


### PR DESCRIPTION
fixing a bug introduced in #194 