### PR TITLE
Fix miniconda download URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
     - export LABEL_NAME=main
     # Only run the upload if the binstar token is present.
     - export UPLOAD_CHANNELS=$(if [ -z ${BINSTAR_TOKEN+x} ]; then echo ""; else echo "--upload-channels scitools/label/${LABEL_NAME}"; fi)
-    - wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+    - curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/master/bootstrap-obvious-ci-and-miniconda.py
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     - conda config --add channels scitools
     - conda config --set show_channel_urls True

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ install:
     - cmd: if defined BINSTAR_TOKEN set "UPLOAD_CHANNELS=--upload-channels scitools/label/%LABEL_NAME%"
     - cmd: echo %UPLOAD_CHANNELS%
 
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
+    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% 3 --without-obvci
     - cmd: set CONDA_PY=%CONDA_PY%
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts


### PR DESCRIPTION
@bjlittle we don't need to wait for @pelson :wink: 

This should fix the problem in https://github.com/SciTools/conda-recipes-scitools/pull/210#issuecomment-259736232

PS: That is the same version of the bootstrap we are using in `conda-forge` and I believe the `conda-smithy` repo will be the place to support it in the longer term.