### PR TITLE
pin conda-build to 2.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     - conda config --add channels scitools
     - conda config --set show_channel_urls True
-    - conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.6
+    - conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.10
     - conda update -n root --yes --quiet conda
     - conda install -n root --yes --quiet jinja2 anaconda-client
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ install:
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     - conda config --add channels scitools
     - conda config --set show_channel_urls True
-    - conda install --yes --quiet -c conda-forge conda-build-all
-    - conda update -n root --yes --quiet conda conda-build
+    - conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.6
+    - conda update -n root --yes --quiet conda
     - conda install -n root --yes --quiet jinja2 anaconda-client
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,8 +62,8 @@ install:
     - cmd: conda config --set show_channel_urls yes
 
     - cmd: conda install --yes --quiet -c conda-forge obvious-ci
-    - cmd: conda install --yes --quiet -c conda-forge conda-build-all
-    - cmd: conda update --yes --quiet conda conda-build
+    - cmd: conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.6
+    - cmd: conda update --yes --quiet conda
     - cmd: conda install --yes --quiet jinja2 anaconda-client
 
     - cmd: conda info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
     - cmd: conda config --set show_channel_urls yes
 
     - cmd: conda install --yes --quiet -c conda-forge obvious-ci
-    - cmd: conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.6
+    - cmd: conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.10
     - cmd: conda update --yes --quiet conda
     - cmd: conda install --yes --quiet jinja2 anaconda-client
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -42,7 +42,7 @@ conda config --add channels scitools
 conda config --set show_channel_urls True
 
 # Update both conda-build-all and conda-build to get latest "numpy x.x" specification support.
-conda install --yes --quiet -c conda-forge conda-build-all conda-build
+conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.10
 conda update --yes --force conda
 conda install -n root --yes --quiet jinja2 anaconda-client
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -42,8 +42,8 @@ conda config --add channels scitools
 conda config --set show_channel_urls True
 
 # Update both conda-build-all and conda-build to get latest "numpy x.x" specification support.
-conda install --yes --quiet -c conda-forge conda-build-all
-conda update --yes --force conda conda-build
+conda install --yes --quiet -c conda-forge conda-build-all conda-build
+conda update --yes --force conda
 conda install -n root --yes --quiet jinja2 anaconda-client
 
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.


### PR DESCRIPTION
pin conda-build to 2.0.6

API changes have broken aspects of conda-build-all