### PR TITLE
remove iris-grib dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
     - conda config --set show_channel_urls True
     - conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.10
     - conda install -n root --yes --quiet conda==4.2.13 jinja2 anaconda-client
+    - conda list
 
 script:
     - conda-build-all ./ --inspect-channels scitools/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,,<=1.10" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,7 @@ install:
     - cmd: conda install --yes --quiet -c conda-forge obvious-ci
     - cmd: conda install --yes --quiet -c conda-forge conda-build-all conda-build==2.0.10
     - cmd: conda install --yes --quiet conda==4.2.13 jinja2 anaconda-client
+    - cmd: conda list
 
     - cmd: conda info
 

--- a/imagehash/bld.bat
+++ b/imagehash/bld.bat
@@ -1,0 +1,1 @@
+"%PYTHON%" setup.py install

--- a/imagehash/meta.yaml
+++ b/imagehash/meta.yaml
@@ -8,7 +8,6 @@ source:
   md5: 0bf909b6d138768f80dd689be7bedaaa
 
 build:
-  skip: True  # [win]
   number: 0
 
 requirements:
@@ -17,11 +16,13 @@ requirements:
     - scipy
     - pillow
     - pywavelets
+    - olefile  # [win]
   run:
     - python
     - scipy
     - pillow
     - pywavelets
+    - olefile  # [win]
 
 test:
   imports:

--- a/iris/bld.bat
+++ b/iris/bld.bat
@@ -2,7 +2,4 @@ set SITECFG=lib/iris/etc/site.cfg
 echo [System] > %SITECFG%
 echo udunits2_path = %SCRIPTS%\udunits2.dll >> %SITECFG%
 
-rmdir lib\iris\tests\results /s /q
-del lib\iris\tests\*.npz
-
 %PYTHON% setup.py install --single-version-externally-managed --record record.txt

--- a/iris/build.sh
+++ b/iris/build.sh
@@ -8,6 +8,4 @@ SITECFG=lib/iris/etc/site.cfg
 echo "[System]" > $SITECFG
 echo "udunits2_path = $PREFIX/lib/libudunits2${SHLIB_EXT}" >> $SITECFG 
 
-rm -rf lib/iris/tests/results lib/iris/tests/*.npz
-
-$PYTHON -sE setup.py --with-unpack build_ext "-I${PREFIX}/include" "-L${PREFIX}/lib" "-R${PREFIX}/lib" install --single-version-externally-managed --record record.txt
+$PYTHON -sE setup.py install --single-version-externally-managed --record record.txt

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - biggus >=0.14
         - cartopy >=0.14
         - netcdf4
-        - numpy x.x
+        - numpy
         - udunits2
         - cf_units
         - pyke
@@ -35,8 +35,7 @@ requirements:
         - cartopy >=0.14
         - matplotlib
         - netcdf4
-        # There is a numpy C ABI dependency for as long as we have a C extension (pp_packing).
-        - numpy x.x
+        - numpy
         - pyke
         - udunits2
         - cf_units

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -42,6 +42,9 @@ requirements:
         - cf_units
         - mo_pack  # [not win]
         - nc_time_axis
+        - pep8
+        - filelock
+        - imagehash
 
 test:
     imports:

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -46,7 +46,6 @@ requirements:
 test:
     imports:
         - iris
-        - iris.fileformats.pp_packing  # [not win]
     commands:
         - python -c "import iris; print('version = {}'.format(iris.__version__))"
 

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -27,7 +27,6 @@ requirements:
         - setuptools
         - mo_pack  # [not win]
         - nc_time_axis
-        - iris_grib  # [not win]
     run:
         - python  # [not osx]
         - python >=2.7,<3  # [osx]
@@ -36,7 +35,6 @@ requirements:
         - cartopy >=0.14
         - matplotlib
         - netcdf4
-        - ecmwf_grib >=1.12.1  # [not win]
         # There is a numpy C ABI dependency for as long as we have a C extension (pp_packing).
         - numpy x.x
         - pyke
@@ -44,7 +42,6 @@ requirements:
         - cf_units
         - mo_pack  # [not win]
         - nc_time_axis
-        - iris_grib  # [not win and not py3k]
 
 test:
     imports:

--- a/olefile/meta.yaml
+++ b/olefile/meta.yaml
@@ -1,0 +1,26 @@
+{% set name = "olefile" %}
+{% set version = "0.42.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: 8a3226dba11349b51a2c6de6af0c889324201f14a8c30992b7877109090e36e0
+
+build:
+    number: 1
+    script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - olefile

--- a/pywavelets/meta.yaml
+++ b/pywavelets/meta.yaml
@@ -10,7 +10,6 @@ source:
     md5: 5b41cd6bf4bd7645aee8eaae72816853
 
 build:
-    skip: True  # [win]
     number: 0
     script: python setup.py install
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -53,6 +53,7 @@ conda install --yes anaconda-client
 conda install --yes conda-build==2.0.10
 conda install --yes conda==4.2.13
 conda info
+conda list
 unset LANG
 yum install -y expat-devel git autoconf libtool texinfo check-devel gcc-gfortran
 


### PR DESCRIPTION
iris-grib ought not to be an iris dependency, as it is not available across platforms and python version