### PR TITLE
Set numpy condition to allow version 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ install:
     - conda install -n root --yes --quiet jinja2 anaconda-client
 
 script:
-    - conda-build-all ./ --inspect-channels scitools/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,,<=1.10" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"
+    - conda-build-all ./ --inspect-channels scitools/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,,<=1.11" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ install:
     - conda install -n root --yes --quiet jinja2 anaconda-client
 
 script:
-    - conda-build-all ./ --inspect-channels scitools/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,,<=1.11" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"
+    - conda-build-all ./ --inspect-channels scitools/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.9,<=1.11" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,4 +72,4 @@ install:
 build: off
 
 test_script:
-    - '%CMD_IN_ENV% conda-build-all .\ --inspect-channels scitools/label/%LABEL_NAME% %UPLOAD_CHANNELS% --matrix-condition "numpy >=1.8,<=1.10" "%PY_CONDITION%"'
+    - '%CMD_IN_ENV% conda-build-all .\ --inspect-channels scitools/label/%LABEL_NAME% %UPLOAD_CHANNELS% --matrix-condition "numpy >=1.8,<=1.11" "%PY_CONDITION%"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,4 +72,4 @@ install:
 build: off
 
 test_script:
-    - '%CMD_IN_ENV% conda-build-all .\ --inspect-channels scitools/label/%LABEL_NAME% %UPLOAD_CHANNELS% --matrix-condition "numpy >=1.8,<=1.11" "%PY_CONDITION%"'
+    - '%CMD_IN_ENV% conda-build-all .\ --inspect-channels scitools/label/%LABEL_NAME% %UPLOAD_CHANNELS% --matrix-condition "numpy >=1.9,<=1.11" "%PY_CONDITION%"'

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -55,6 +55,6 @@ conda info
 unset LANG
 yum install -y expat-devel git autoconf libtool texinfo check-devel gcc-gfortran
 
-conda-build-all /conda-recipes --inspect-channels $UPLOAD_OWNER/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,<=1.10" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"
+conda-build-all /conda-recipes --inspect-channels $UPLOAD_OWNER/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,<=1.11" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"
 
 EOF

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -55,6 +55,6 @@ conda info
 unset LANG
 yum install -y expat-devel git autoconf libtool texinfo check-devel gcc-gfortran
 
-conda-build-all /conda-recipes --inspect-channels $UPLOAD_OWNER/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.8,<=1.11" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"
+conda-build-all /conda-recipes --inspect-channels $UPLOAD_OWNER/label/${LABEL_NAME} ${UPLOAD_CHANNELS} --matrix-condition "numpy >=1.9,<=1.11" "python >=2.7,<3|>=3.4,<3.5|>=3.5,<3.6"
 
 EOF


### PR DESCRIPTION
I don't know why there is the restriction to building numpy <= 1.10, now that all the work getting iris to work with different versions of numpy/matplotlib/netcdf has been done.

It has been shown that the iris tests pass in an environment which includes numpy 1.11.1.

I suggest we bump up the upper limit of what version numpy can be (as the PR demonstrates) or we could remove the upper limit altogether and just have
` --matrix-condition "numpy >=1.8"`
?