### PR TITLE
Update udunits to v2.2.21.

### DIFF
--- a/udunits2/bld.bat
+++ b/udunits2/bld.bat
@@ -10,9 +10,9 @@ mkdir %LIBRARY_PREFIX%\share
 mkdir %LIBRARY_PREFIX%\share\udunits
 copy ..\lib\*.xml %LIBRARY_PREFIX%\share\udunits\
 
+copy %RECIPE_DIR%\unistd.h %SRC_DIR% || exit 1
 
-copy %RECIPE_DIR%\unistd.h .
-cmake .. -G "NMake Makefiles" -DEXPAT_INCLUDE_DIR:PATH=%LIBRARY_INC%\expat.h -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX%  -DCMAKE_BUILD_TYPE=Release
+cmake -G "NMake Makefiles" -DEXPAT_INCLUDE_DIR:PATH=%LIBRARY_INC%\expat.h -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX%  -DCMAKE_BUILD_TYPE=Release %SRC_DIR%
 
 nmake libudunits2 || exit 1
 nmake udunits2 || exit 1

--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "2.2.21" %}
+
 package:
     name: udunits2
-    version: 2.2.20
+    version: {{ version }}
 
 source:
-    fn: v2.2.20.tar.gz
-    url: https://github.com/Unidata/UDUNITS-2/archive/v2.2.20.tar.gz
-    sha1: a0d30024af16749a4a5ca60133b32735ae52f9e2
+    fn: udunits-{{ version }}.tar.gz
+    url: ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-{{ version }}.tar.gz
+    sha1: 4afc6d767d38e720f2898674e09dc3720a4b131e
 
 requirements:
   build:

--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -9,22 +9,28 @@ source:
     url: ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-{{ version }}.tar.gz
     sha1: 4afc6d767d38e720f2898674e09dc3720a4b131e
 
-requirements:
-  build:
-    - cmake  # [win]
-    - expat  # [win]
-    - vc 9  # [win]
-    - vc 10  # [win]
-    - vc 14  # [win]
-  run:
-    - expat  # [win]
-    - vc 9  # [win]
-    - vc 10  # [win]
-    - vc 14  # [win]
-
 build:
     number: 0
     detect_binary_files_with_prefix: true
+    features:
+      - vc9  # [win and py27]
+      - vc10  # [win and py34]
+      - vc14  # [win and py>=35]
+
+
+requirements:
+  build:
+    - python  # [win]
+    - cmake  # [win]
+    - expat  # [win]
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+  run:
+    - expat  # [win]
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
 
 test:
     commands:

--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -11,9 +11,16 @@ source:
 
 requirements:
   build:
+    - cmake  # [win]
     - expat  # [win]
+    - vc 9  # [win]
+    - vc 10  # [win]
+    - vc 14  # [win]
   run:
     - expat  # [win]
+    - vc 9  # [win]
+    - vc 10  # [win]
+    - vc 14  # [win]
 
 build:
     number: 0


### PR DESCRIPTION
Hopefully this updated version of udunits2 will fix the long-standing issues we've had using udunits2 on Windows (see, as a starting point, #115).

Given that these builds will run using conda-build 2.0.10, I'm hopeful that this will also fix #226. 