### PR TITLE
Set shared object file extensions using conda-build

### DIFF
--- a/iris/build.sh
+++ b/iris/build.sh
@@ -3,15 +3,10 @@
 # Make sure Iris can find the udunits library while it's in the temporary
 # build environment. This is necessary because the build process also compiles
 # the pyke rules, which requires importing iris.
-if [[ $(uname) == Darwin ]]; then
-    EXT=dylib
-else
-    EXT=so
-fi
 
 SITECFG=lib/iris/etc/site.cfg
 echo "[System]" > $SITECFG
-echo "udunits2_path = $PREFIX/lib/libudunits2.${EXT}" >> $SITECFG 
+echo "udunits2_path = $PREFIX/lib/libudunits2${SHLIB_EXT}" >> $SITECFG 
 
 rm -rf lib/iris/tests/results lib/iris/tests/*.npz
 

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -9,7 +9,7 @@ source:
     git_tag: v{{ version }}
 
 build:
-    number: 0
+    number: 1
     skip: True  # [py35]
 
 requirements:


### PR DESCRIPTION
There's a new(ish) environment variable available during conda builds, which sets the platform-specific file extension for shared objects. This PR updates the Iris recipe to make use of this environment variable, so that we do not have to set it ourselves.