### PR TITLE
Pin netcdf4 version

### DIFF
--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -19,7 +19,7 @@ requirements:
         - scipy
         - biggus >=0.14
         - cartopy >=0.14
-        - netcdf4
+        - netcdf4 <=1.2.4
         - numpy
         - udunits2
         - cf_units
@@ -34,7 +34,7 @@ requirements:
         - biggus >=0.14
         - cartopy >=0.14
         - matplotlib
-        - netcdf4
+        - netcdf4 <=1.2.4
         - numpy
         - pyke
         - udunits2

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -9,7 +9,7 @@ source:
     git_tag: v{{ version }}
 
 build:
-    number: 2
+    number: 3
     skip: True  # [py35]
 
 requirements:


### PR DESCRIPTION
The latest version of netcdf4 (v1.2.7) is not compatible with Iris:
```python
import datetime
import os

import iris
from iris.time import PartialDateTime


iris.FUTURE.cell_datetime_objects = True

fn = 'A1B_north_america.nc'
cube = iris.load_cube(iris.sample_data_path(fn))
cube.coord('time').bounds = None

dt = datetime.datetime(2014, 12, 22)
pdt = PartialDateTime(year=dt.year, month=dt.month, day=dt.day)

t_cstr = iris.Constraint(time=lambda cell: cell < pdt)
subcube = cube.extract(t_cstr)

Traceback (most recent call last):
  File "/.../sample_code.py", line 43, in <module>
    baseline_cube = cube.extract(baseline_cstr)
  File "/.../miniconda/envs/dist_forge/lib/python2.7/site-packages/iris/cube.py", line 2312, in extract
    return constraint.extract(self)
  File "/.../envs/dist_forge/lib/python2.7/site-packages/iris/_constraints.py", line 151, in extract
    resultant_CIM = self._CIM_extract(cube)
  File "/.../miniconda/envs/dist_forge/lib/python2.7/site-packages/iris/_constraints.py", line 175, in _CIM_extract
    resultant_CIM = resultant_CIM & coord_constraint.extract(cube)
  File "/.../miniconda/envs/dist_forge/lib/python2.7/site-packages/iris/_constraints.py", line 290, in extract
    r = np.array([call_func(cell) for cell in coord.cells()])
  File "/.../sample_code.py", line 42, in <lambda>
    baseline_cstr = iris.Constraint(time=lambda c: baseline[0] < c <= baseline[1])
  File "/.../miniconda/envs/dist_forge/lib/python2.7/functools.py", line 62, in <lambda>
    '__gt__': [('__lt__', lambda self, other: not (self > other or self == other)),
  File "/.../miniconda/envs/dist_forge/lib/python2.7/site-packages/iris/coords.py", line 346, in __lt__
    return self.__common_cmp__(other, operator.lt)
  File "/.../miniconda/envs/dist_forge/lib/python2.7/site-packages/iris/coords.py", line 332, in __common_cmp__
    result = operator_method(me, other)
  File "netcdftime/_netcdftime.pyx", line 1295, in netcdftime._netcdftime.datetime.__richcmp__ (netcdftime/_netcdftime.c:23410)
TypeError: cannot compare netcdftime._netcdftime.Datetime360Day(1861, 6, 30, 12, 0, 0, 0, -1, 180) and PartialDateTime(year=1986, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
```

This pins netcdf4 to v1.2.4, which does not cause the failure quoted above.