### PR TITLE
Update iris recipe for Iris v1.12.0 release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda list
-    - cmd: conda install --yes ruamel ruamel-yaml
+    - cmd: conda install --yes ruamel_yaml
     - cmd: conda list
     - cmd: conda install --yes --force python=3.5
     - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,13 @@ install:
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda list
+    - cmd: conda install --yes ruamel ruamel-yaml
+    - cmd: conda list
+    - cmd: conda install --yes --force python=3.5
+    - cmd: conda list
+
+
     - cmd: conda config --add channels scitools
     - cmd: conda config --set show_channel_urls yes
 

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.11.0" %}
+{% set version = "1.12.0" %}
 
 package:
     name: iris
@@ -9,7 +9,7 @@ source:
     git_tag: v{{ version }}
 
 build:
-    number: 2
+    number: 0
     skip: True  # [py35]
 
 requirements:

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
     number: 0
-    skip: True  # [py35]
+    skip: True  # [py35 or osx or win]
 
 requirements:
     build:


### PR DESCRIPTION
Based on https://github.com/SciTools/conda-recipes-scitools/pull/233 but set to skip OSX and Windows.

@lbdreyer @bjlittle 