### PR TITLE
Mule recipe: Add sha256 to recipe and rename downloaded file.

### DIFF
--- a/mule/meta.yaml
+++ b/mule/meta.yaml
@@ -1,13 +1,18 @@
+{% set name = "mule" %}
+{% set version = "1.4" %}
+{% set sha256 = "e67700c4ee9d1d63a19a8b68b3ec8acdbc9b59acdbfe0a885c7e07e85d641e52" %}
+
 package:
-    name: mule
-    version: 1.4
+    name: {{ name|lower }}
+    version: {{ version }}
 
 source:
-    fn: mule.tar.gz
-    url: https://github.com/SciTools/mule/releases/download/vn1.4/mule.tar.gz
+    fn: {{ name }}-{{ version }}.tar.gz
+    url: https://github.com/SciTools/{{ name }}/releases/download/vn{{ version }}/{{ name }}.tar.gz
+    sha256: {{ sha256 }}
 
 build:
-    number: 0
+    number: 1
     skip: True # [py3k or win]
     script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
This adds a sha256 so that we can check we are downloading the correct file.
This also renames the file we download so that we can distinguish between different versions of mule in our download cache.

I'm just putting this up here to remember the changes that need to be made. we may well think about moving this onto conda-forge