### PR TITLE
Updated to ImageMetaTag vn0.6.3

### DIFF
--- a/image-meta-tag/meta.yaml
+++ b/image-meta-tag/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: image-meta-tag
-    version: "0.4.3"
+    version: "0.6.3"
 
 source:
     git_url: https://github.com/SciTools-incubator/image-meta-tag
-    git_tag: 0.4.3
+    git_tag: 0.6.3
 
 build:
     number: 0


### PR DESCRIPTION
Update to ImageMetaTag vn0.6.3.

This time, I think, the rest of the recipes are up to date so the build might work.